### PR TITLE
perf(ip-restriction): optimize ip-restriction middleware by prepare matcher function in advance

### DIFF
--- a/src/middleware/ip-restriction/index.test.ts
+++ b/src/middleware/ip-restriction/index.test.ts
@@ -1,8 +1,9 @@
 import { Hono } from '../../hono'
 import { Context } from '../../context'
 import { HonoRequest } from '../../request'
-import type { GetConnInfo } from '../../helper/conninfo'
+import type { AddressType, GetConnInfo } from '../../helper/conninfo'
 import { ipRestriction } from '.'
+import type { IPRestrictRule } from '.'
 
 describe('ipRestriction middleware', () => {
   it('Should restrict', async () => {
@@ -63,12 +64,12 @@ describe('ipRestriction middleware', () => {
 })
 
 describe('isMatchForRule', () => {
-  const isMatch = async (connInfo, rule) => {
+  const isMatch = async (info: { addr: string; type: AddressType }, rule: IPRestrictRule) => {
     const middleware = ipRestriction(
       () => ({
         remote: {
-          address: connInfo.addr,
-          addressType: connInfo.type,
+          address: info.addr,
+          addressType: info.type,
         },
       }),
       {

--- a/src/middleware/ip-restriction/index.ts
+++ b/src/middleware/ip-restriction/index.ts
@@ -75,7 +75,11 @@ const buildMatcher = (
       if (type === 'unknown') {
         throw new TypeError(`Invalid rule: ${rule}`)
       }
-      staticRules.add(type === 'IPv4' ? rule : convertIPv6ToString(convertIPv6ToBinary(rule)))
+      staticRules.add(
+        type === 'IPv4'
+          ? rule // IPv4 address is already normalized, so it is registered as is.
+          : convertIPv6ToString(convertIPv6ToBinary(rule)) // normalize IPv6 address (e.g. 0000:0000:0000:0000:0000:0000:0000:0001 => ::1)
+      )
     }
   }
 

--- a/src/middleware/ip-restriction/index.ts
+++ b/src/middleware/ip-restriction/index.ts
@@ -8,8 +8,8 @@ import type { AddressType, GetConnInfo } from '../../helper/conninfo'
 import { HTTPException } from '../../http-exception'
 import {
   convertIPv4ToBinary,
+  convertIPv6BinaryToString,
   convertIPv6ToBinary,
-  convertIPv6ToString,
   distinctRemoteAddr,
 } from '../../utils/ipaddr'
 
@@ -78,7 +78,7 @@ const buildMatcher = (
       staticRules.add(
         type === 'IPv4'
           ? rule // IPv4 address is already normalized, so it is registered as is.
-          : convertIPv6ToString(convertIPv6ToBinary(rule)) // normalize IPv6 address (e.g. 0000:0000:0000:0000:0000:0000:0000:0001 => ::1)
+          : convertIPv6BinaryToString(convertIPv6ToBinary(rule)) // normalize IPv6 address (e.g. 0000:0000:0000:0000:0000:0000:0000:0001 => ::1)
       )
     }
   }

--- a/src/utils/ipaddr.test.ts
+++ b/src/utils/ipaddr.test.ts
@@ -1,4 +1,10 @@
-import { convertIPv4ToBinary, convertIPv6ToBinary, distinctRemoteAddr, expandIPv6 } from './ipaddr'
+import {
+  convertIPv4ToBinary,
+  convertIPv6ToBinary,
+  convertIPv6ToString,
+  distinctRemoteAddr,
+  expandIPv6,
+} from './ipaddr'
 
 describe('expandIPv6', () => {
   it('Should result be valid', () => {
@@ -35,5 +41,21 @@ describe('convertIPv6ToBinary', () => {
     expect(convertIPv6ToBinary('::1')).toBe(1n)
 
     expect(convertIPv6ToBinary('::f')).toBe(15n)
+    expect(convertIPv6ToBinary('1234:::5678')).toBe(24196103360772296748952112894165669496n)
+  })
+})
+
+describe('convertIPv6ToString', () => {
+  // add tons of test cases here
+  test.each`
+    input                                        | expected
+    ${'::1'}                                     | ${'::1'}
+    ${'1::'}                                     | ${'1::'}
+    ${'1234:::5678'}                             | ${'1234::5678'}
+    ${'2001:2::'}                                | ${'2001:2::'}
+    ${'2001::db8:0:0:0:0:1'}                     | ${'2001:0:db8::1'}
+    ${'1234:5678:9abc:def0:1234:5678:9abc:def0'} | ${'1234:5678:9abc:def0:1234:5678:9abc:def0'}
+  `('convertIPv6ToString($input) === $expected', ({ input, expected }) => {
+    expect(convertIPv6ToString(convertIPv6ToBinary(input))).toBe(expected)
   })
 })

--- a/src/utils/ipaddr.test.ts
+++ b/src/utils/ipaddr.test.ts
@@ -1,7 +1,7 @@
 import {
   convertIPv4ToBinary,
+  convertIPv6BinaryToString,
   convertIPv6ToBinary,
-  convertIPv6ToString,
   distinctRemoteAddr,
   expandIPv6,
 } from './ipaddr'
@@ -56,6 +56,6 @@ describe('convertIPv6ToString', () => {
     ${'2001::db8:0:0:0:0:1'}                     | ${'2001:0:db8::1'}
     ${'1234:5678:9abc:def0:1234:5678:9abc:def0'} | ${'1234:5678:9abc:def0:1234:5678:9abc:def0'}
   `('convertIPv6ToString($input) === $expected', ({ input, expected }) => {
-    expect(convertIPv6ToString(convertIPv6ToBinary(input))).toBe(expected)
+    expect(convertIPv6BinaryToString(convertIPv6ToBinary(input))).toBe(expected)
   })
 })

--- a/src/utils/ipaddr.ts
+++ b/src/utils/ipaddr.ts
@@ -72,11 +72,11 @@ export const convertIPv6ToBinary = (ipv6: string): bigint => {
 }
 
 /**
- * Convert IPv6 to String
+ * Convert a binary representation of an IPv6 address to a string.
  * @param ipV6 binary IPv6 Address
  * @return normalized IPv6 Address in string
  */
-export const convertIPv6ToString = (ipV6: bigint): string => {
+export const convertIPv6BinaryToString = (ipV6: bigint): string => {
   const sections = []
   for (let i = 0; i < 8; i++) {
     sections.push(((ipV6 >> BigInt(16 * (7 - i))) & 0xffffn).toString(16))

--- a/src/utils/ipaddr.ts
+++ b/src/utils/ipaddr.ts
@@ -70,3 +70,45 @@ export const convertIPv6ToBinary = (ipV6: string): bigint => {
   }
   return result
 }
+
+/**
+ * Convert IPv4 to String
+ * @param ipV6 binary IPv6 Address
+ * @return normalized IPv6 Address in string
+ */
+export const convertIPv6ToString = (ipV6: bigint): string => {
+  const sections = []
+  for (let i = 0; i < 8; i++) {
+    sections.push(((ipV6 >> BigInt(16 * (7 - i))) & 0xffffn).toString(16))
+  }
+
+  let currentZeroStart = -1
+  let maxZeroStart = -1
+  let maxZeroEnd = -1
+  for (let i = 0; i < 8; i++) {
+    if (sections[i] === '0') {
+      if (currentZeroStart === -1) {
+        currentZeroStart = i
+      }
+    } else {
+      if (currentZeroStart > -1) {
+        if (i - currentZeroStart > maxZeroEnd - maxZeroStart) {
+          maxZeroStart = currentZeroStart
+          maxZeroEnd = i
+        }
+        currentZeroStart = -1
+      }
+    }
+  }
+  if (currentZeroStart > -1) {
+    if (8 - currentZeroStart > maxZeroEnd - maxZeroStart) {
+      maxZeroStart = currentZeroStart
+      maxZeroEnd = 8
+    }
+  }
+  if (maxZeroStart !== -1) {
+    sections.splice(maxZeroStart, maxZeroEnd - maxZeroStart, ':')
+  }
+
+  return sections.join(':').replace(/:{2,}/g, '::')
+}

--- a/src/utils/ipaddr.ts
+++ b/src/utils/ipaddr.ts
@@ -72,7 +72,7 @@ export const convertIPv6ToBinary = (ipv6: string): bigint => {
 }
 
 /**
- * Convert IPv4 to String
+ * Convert IPv6 to String
  * @param ipV6 binary IPv6 Address
  * @return normalized IPv6 Address in string
  */


### PR DESCRIPTION
The following optimisations were added.

* As far as possible, parse and prepare the IP address of the rule at the initialisation of the application.
* Returns true immediately if '*' is included.
* IP addresses passed from the environment can be assumed to be in a normalised state by functions such as inet_ntop, so use Set to check for static IP addresses

### The author should do the following, if applicable

- [x] Add tests
- [x] Run tests
- [x] `bun run format:fix && bun run lint:fix` to format the code
- [x] Add [TSDoc](https://tsdoc.org/)/[JSDoc](https://jsdoc.app/about-getting-started) to document the code
